### PR TITLE
update dnsmasq container to 2.78

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM andyshinn/dnsmasq:2.76
+FROM andyshinn/dnsmasq:2.78
 MAINTAINER Chris Schmich <schmch@gmail.com>
 COPY dnsmasq.conf /etc/dnsmasq.conf
 COPY update-hosts.sh /etc/periodic/daily/update-hosts

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,8 @@ MAINTAINER Chris Schmich <schmch@gmail.com>
 COPY dnsmasq.conf /etc/dnsmasq.conf
 COPY update-hosts.sh /etc/periodic/daily/update-hosts
 COPY start.sh /srv/purify/start.sh
-RUN apk add --no-cache curl \
+RUN apk add --upgrade apk-tools@edge \
+ && apk add --no-cache curl \
  && chmod +x /etc/periodic/daily/update-hosts \
  && /etc/periodic/daily/update-hosts \
  && chmod +x /srv/purify/start.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,8 @@ MAINTAINER Chris Schmich <schmch@gmail.com>
 COPY dnsmasq.conf /etc/dnsmasq.conf
 COPY update-hosts.sh /etc/periodic/daily/update-hosts
 COPY start.sh /srv/purify/start.sh
-RUN apk add --upgrade apk-tools@edge \
+RUN apk update \
+ && apk add --upgrade apk-tools@edge \
  && apk add --no-cache curl \
  && chmod +x /etc/periodic/daily/update-hosts \
  && /etc/periodic/daily/update-hosts \

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,8 @@ MAINTAINER Chris Schmich <schmch@gmail.com>
 COPY dnsmasq.conf /etc/dnsmasq.conf
 COPY update-hosts.sh /etc/periodic/daily/update-hosts
 COPY start.sh /srv/purify/start.sh
-RUN apk update \
+RUN echo "@edge http://nl.alpinelinux.org/alpine/edge/main" >> /etc/apk/repositories \
+ && apk update \
  && apk add --upgrade apk-tools@edge \
  && apk add --no-cache curl \
  && chmod +x /etc/periodic/daily/update-hosts \


### PR DESCRIPTION
Dnsmasq version is more recent, but Alpine is based on Edge release.
Versions < 2.78 can crash due to : https://www.cvedetails.com/cve/CVE-2017-13704 .

Thanks for considering this.